### PR TITLE
Set release tag name explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,6 +289,7 @@ jobs:
         with:
           draft: false
           prerelease: true
+          tag_name: ${{ needs.prepare-tag.outputs.tag_name }}
           name: "${{ needs.prepare-tag.outputs.tag_name }} - GaleFling"
           body: ${{ steps.release_notes.outputs.body }}
           files: |


### PR DESCRIPTION
Passes the prepared tag to softprops/action-gh-release as tag_name so master-merge auto-tag releases publish against the generated tag. The orphan v1.8.12 tag from the failed run was removed so this corrected workflow can recreate it.\n\nFollow-up for Odoo task 212.