### PR TITLE
Enable Dependabot auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       time: '09:00'
       timezone: 'America/Los_Angeles'
     open-pull-requests-limit: 5
+    auto-merge: enable
     groups:
       python-dependencies:
         patterns:
@@ -21,6 +22,7 @@ updates:
       time: '09:00'
       timezone: 'America/Los_Angeles'
     open-pull-requests-limit: 5
+    auto-merge: enable
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Add `auto-merge: enable` to all Dependabot ecosystem blocks so that Dependabot PRs are automatically merged once required checks pass.

Also adds `dependabot.yml` where it was missing (`trakt_watchlist_monitor`, `twitch_vod_downloader`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)